### PR TITLE
Fixing regex bug

### DIFF
--- a/.github/workflows/composite/generate-sdk/action.yml
+++ b/.github/workflows/composite/generate-sdk/action.yml
@@ -28,6 +28,9 @@ runs:
     - name: Download spec files
       shell: bash
       run: wget ${{ inputs.spec-link }} -O ./${{ inputs.module-name }}/${{ inputs.module-name }}.spec.yaml
+    - name: Fix regex in generated code
+      shell: bash
+      run: ./fix-regex.sh ${{ inputs.module-name }}
     - name: Upload Artifacts
       uses: actions/upload-artifact@v2
       with:

--- a/NetworkStorageApi/lib/pnap_network_storage_api/models/volume_create.rb
+++ b/NetworkStorageApi/lib/pnap_network_storage_api/models/volume_create.rb
@@ -119,7 +119,7 @@ module NetworkStorageApi
         invalid_properties.push('invalid value for "path_suffix", the character length must be great than or equal to 1.')
       end
 
-      pattern = Regexp.new(/^(\\/[\w-]+)+$/)
+      pattern = Regexp.new(/^(\/[\w-]+)+$/)
       if !@path_suffix.nil? && @path_suffix !~ pattern
         invalid_properties.push("invalid value for \"path_suffix\", must conform to the pattern #{pattern}.")
       end

--- a/NetworkStorageApi/lib/pnap_network_storage_api/models/volume_create.rb
+++ b/NetworkStorageApi/lib/pnap_network_storage_api/models/volume_create.rb
@@ -119,7 +119,7 @@ module NetworkStorageApi
         invalid_properties.push('invalid value for "path_suffix", the character length must be great than or equal to 1.')
       end
 
-      pattern = Regexp.new(/^(\\/[\w-]+)+$/)
+      pattern = Regexp.new(/^(\/[\w-]+)+$/)
       if !@path_suffix.nil? && @path_suffix !~ pattern
         invalid_properties.push("invalid value for \"path_suffix\", must conform to the pattern #{pattern}.")
       end
@@ -144,7 +144,7 @@ module NetworkStorageApi
       return false if !@description.nil? && @description.to_s.length > 250
       return false if !@path_suffix.nil? && @path_suffix.to_s.length > 27
       return false if !@path_suffix.nil? && @path_suffix.to_s.length < 1
-      return false if !@path_suffix.nil? && @path_suffix !~ Regexp.new(/^(\\/[\w-]+)+$/)
+      return false if !@path_suffix.nil? && @path_suffix !~ Regexp.new(/^(\/[\w-]+)+$/)
       return false if @capacity_in_gb.nil?
       return false if @capacity_in_gb < 1000
       true
@@ -189,7 +189,7 @@ module NetworkStorageApi
         fail ArgumentError, 'invalid value for "path_suffix", the character length must be great than or equal to 1.'
       end
 
-      pattern = Regexp.new(/^(\\/[\w-]+)+$/)
+      pattern = Regexp.new(/^(\/[\w-]+)+$/)
       if !path_suffix.nil? && path_suffix !~ pattern
         fail ArgumentError, "invalid value for \"path_suffix\", must conform to the pattern #{pattern}."
       end

--- a/NetworkStorageApi/lib/pnap_network_storage_api/models/volume_create.rb
+++ b/NetworkStorageApi/lib/pnap_network_storage_api/models/volume_create.rb
@@ -119,7 +119,7 @@ module NetworkStorageApi
         invalid_properties.push('invalid value for "path_suffix", the character length must be great than or equal to 1.')
       end
 
-      pattern = Regexp.new(/^(\/[\w-]+)+$/)
+      pattern = Regexp.new(/^(\\/[\w-]+)+$/)
       if !@path_suffix.nil? && @path_suffix !~ pattern
         invalid_properties.push("invalid value for \"path_suffix\", must conform to the pattern #{pattern}.")
       end

--- a/NetworkStorageApi/lib/pnap_network_storage_api/models/volume_update.rb
+++ b/NetworkStorageApi/lib/pnap_network_storage_api/models/volume_update.rb
@@ -119,7 +119,7 @@ module NetworkStorageApi
         invalid_properties.push('invalid value for "path_suffix", the character length must be great than or equal to 1.')
       end
 
-      pattern = Regexp.new(/^(\\/[\w-]+)+$/)
+      pattern = Regexp.new(/^(\/[\w-]+)+$/)
       if !@path_suffix.nil? && @path_suffix !~ pattern
         invalid_properties.push("invalid value for \"path_suffix\", must conform to the pattern #{pattern}.")
       end
@@ -136,7 +136,7 @@ module NetworkStorageApi
       return false if !@capacity_in_gb.nil? && @capacity_in_gb < 2000
       return false if !@path_suffix.nil? && @path_suffix.to_s.length > 27
       return false if !@path_suffix.nil? && @path_suffix.to_s.length < 1
-      return false if !@path_suffix.nil? && @path_suffix !~ Regexp.new(/^(\\/[\w-]+)+$/)
+      return false if !@path_suffix.nil? && @path_suffix !~ Regexp.new(/^(\/[\w-]+)+$/)
       true
     end
 
@@ -185,7 +185,7 @@ module NetworkStorageApi
         fail ArgumentError, 'invalid value for "path_suffix", the character length must be great than or equal to 1.'
       end
 
-      pattern = Regexp.new(/^(\\/[\w-]+)+$/)
+      pattern = Regexp.new(/^(\/[\w-]+)+$/)
       if !path_suffix.nil? && path_suffix !~ pattern
         fail ArgumentError, "invalid value for \"path_suffix\", must conform to the pattern #{pattern}."
       end

--- a/fix-regex.sh
+++ b/fix-regex.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+find . -type f -path '*.rb' | xargs sed -i "s/Regexp\.new(.*?)(?:\\\\)+\//Regexp.new\1\\\/g"

--- a/fix-regex.sh
+++ b/fix-regex.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-find . -type f -path '*.rb' | xargs sed -i "s/Regexp\.new(.*?)(?:\\\\)+\//Regexp.new\1\\\/g"
+find . -type f -path '*.rb' | xargs sed -i -s -E "s/Regexp\.new(.*?)(\\\\)+\//Regexp.new\1\\//g"

--- a/fix-regex.sh
+++ b/fix-regex.sh
@@ -1,2 +1,4 @@
 #!/bin/bash
+echo Entering $1...
+cd $1
 find . -type f -path '*.rb' | xargs sed -i -s -E "s/Regexp\.new(.*?)(\\\\)+\//Regexp.new\1\\//g"


### PR DESCRIPTION
The generated code produces erroneous regex which fails the build. This should include a script that's run after generation to try and fix said regex.